### PR TITLE
Fixes 404 error

### DIFF
--- a/src/helpers/load-data.ts
+++ b/src/helpers/load-data.ts
@@ -9,7 +9,7 @@ export default async function loadFile(file: string): Promise<string> {
 	const cachedContent = cache.get<string>(file);
 	if (cachedContent) return cachedContent;
 	// Otherwise cache the request
-	const dataUrl = (file: string): string => `https://raw.githubusercontent.com/github/linguist/HEAD/lib/linguist/${file}`;
+	const dataUrl = (file: string): string => `https://raw.githubusercontent.com/github/linguist/master/lib/linguist/${file}`;
 	const fileContent = await fetch(dataUrl(file)).then(data => data.text());
 	cache.set(file, fileContent);
 	return fileContent;


### PR DESCRIPTION
There seems to be an issue with either Github/Linguist or Github itself, the HEAD doesn't have the *.yml files anymore. Changed to master to make sure the files are still there. A better fix should be considered, for example with an immutable tag.